### PR TITLE
fix: match resource type arn patterns case-insensitively

### DIFF
--- a/src/resourceTypes.test.ts
+++ b/src/resourceTypes.test.ts
@@ -135,6 +135,21 @@ const resourceStringMatchesResourcePatternTests: {
       'arn:${Partition}:s3:::${BucketName}/${ObjectName}': true
     }
   },
+  // Static ARN resource-type labels can differ in case between iam-data and concrete AWS ARNs.
+  {
+    pattern:
+      'arn:AWS:GuardDuty:us-east-1:123456789012:detector/example-detector/publishingDestination/example-destination',
+    matches: {
+      'arn:${Partition}:guardduty:${Region}:${Account}:detector/${DetectorId}/publishingdestination/${PublishingDestinationId}': true
+    }
+  },
+  {
+    pattern:
+      'arn:aws:guardduty:us-east-1:123456789012:detector/example-detector/publishingdestination/example-destination',
+    matches: {
+      'arn:${Partition}:guardduty:${Region}:${Account}:detector/${DetectorId}/publishingDestination/${PublishingDestinationId}': true
+    }
+  },
   // A trailing variable spans slashes, so a sub-resource ARN matches its own
   // type AND, deliberately, its parent's. Disambiguating between the two needs
   // the service's full type list and happens in callers that choose one type.

--- a/src/resourceTypes.ts
+++ b/src/resourceTypes.ts
@@ -102,7 +102,7 @@ export function resourceStringMatchesResourceTypePattern(
 
     const resourceComponentPattern =
       '^' + resourceComponent.replace(/\?/g, '.').replace(/\*/g, '.*?') + '$'
-    const regex = new RegExp(resourceComponentPattern)
+    const regex = new RegExp(resourceComponentPattern, 'i')
     const match = patternComponent.match(regex)
     if (match) {
       if (isLastPattern && resourceComponent.endsWith('*')) {
@@ -141,7 +141,16 @@ function resourceComponentMatchesResourceTypeComponent(
   resourceComponent: string | undefined,
   resourceTypeComponent: string | undefined
 ): boolean {
-  if (resourceTypeComponent === '*' || resourceTypeComponent === resourceComponent) {
+  if (resourceTypeComponent === '*') {
+    return true
+  }
+
+  if (
+    resourceComponent !== undefined &&
+    resourceTypeComponent !== undefined &&
+    resourceTypeComponent.localeCompare(resourceComponent, undefined, { sensitivity: 'accent' }) ===
+      0
+  ) {
     return true
   }
 
@@ -155,7 +164,7 @@ function resourceComponentMatchesResourceTypeComponent(
   }
 
   const pattern = convertResourcePatternToRegex(resourceTypeComponent)
-  const regex = new RegExp(pattern)
+  const regex = new RegExp(pattern, 'i')
   const match = resourceComponent.match(regex)
   return !!match
 }


### PR DESCRIPTION
## Summary

- make resource type ARN matching case-insensitive for ARN components and static resource labels
- preserve wildcard and variable matching behavior for resource type shape classification
- add sanitized GuardDuty publishingDestination reproduction coverage, including reverse-case and mixed service casing

## Tests

- npm run build
- npm test
- npm run format-check

## Notes

This change is scoped to @cloud-copilot/iam-utils resource-type pattern recognition used by iam-simulate/whoCan resource type selection. It does not change policy resource identity matching or ARN condition operators.