### PR TITLE
feat: improve resource type pattern matching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,10 @@ export {
 } from './principals.js'
 export { convertResourcePatternToRegex } from './resourcePatterns.js'
 export { resourceArnWithWildcardsToRegex } from './resources.js'
-export { resourceStringMatchesResourceTypePattern } from './resourceTypes.js'
+export {
+  mostSpecificMatchingResourceTypePatterns,
+  resourceStringMatchesResourceTypePattern
+} from './resourceTypes.js'
 export {
   actionSupportsAwsResourceInfoContextKeys,
   isAwsResourceInfoExcludedAction

--- a/src/resourceTypes.test.ts
+++ b/src/resourceTypes.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resourceStringMatchesResourceTypePattern } from './resourceTypes.js'
+import {
+  mostSpecificMatchingResourceTypePatterns,
+  resourceStringMatchesResourceTypePattern
+} from './resourceTypes.js'
 
 const resourceStringMatchesResourcePatternTests: {
   pattern: string
@@ -135,6 +138,108 @@ const resourceStringMatchesResourcePatternTests: {
       'arn:${Partition}:s3:::${BucketName}/${ObjectName}': true
     }
   },
+  // Single-variable resource components do not absorb separators, preserving S3 bucket vs object matching.
+  {
+    pattern: 'arn:aws:s3:::my-bucket/path/to/object.txt',
+    matches: {
+      'arn:${Partition}:s3:::${BucketName}': false,
+      'arn:${Partition}:s3:::${BucketName}/${ObjectName}': true
+    }
+  },
+  {
+    pattern: 'arn:aws:sqs:us-east-1:123456789012:queue/subpath',
+    matches: {
+      'arn:${Partition}:sqs:${Region}:${Account}:${QueueName}': false
+    }
+  },
+  {
+    pattern: 'arn:aws:sqs:us-east-1:123456789012:queue:subpath',
+    matches: {
+      'arn:${Partition}:sqs:${Region}:${Account}:${QueueName}': false
+    }
+  },
+  // IAM wildcards in resource strings are supported, including ? and adjacent wildcard tokens.
+  {
+    pattern: 'arn:aws:s3:::my-bucke?',
+    matches: {
+      'arn:${Partition}:s3:::${BucketName}': true,
+      'arn:${Partition}:s3:::${BucketName}/${ObjectName}': false
+    }
+  },
+  {
+    pattern: 'arn:aws:s3:::my-buck?t/*?',
+    matches: {
+      'arn:${Partition}:s3:::${BucketName}': false,
+      'arn:${Partition}:s3:::${BucketName}/${ObjectName}': true
+    }
+  },
+  {
+    pattern: 'arn:aws:s3:::my-bucket/**',
+    matches: {
+      'arn:${Partition}:s3:::${BucketName}': false,
+      'arn:${Partition}:s3:::${BucketName}/${ObjectName}': true
+    }
+  },
+  {
+    pattern: 'arn:aws:s3:::my-bucket/?*',
+    matches: {
+      'arn:${Partition}:s3:::${BucketName}/${ObjectName}': true
+    }
+  },
+  // Static resource type pattern text is literal, even when it contains regex metacharacters.
+  {
+    pattern: 'arn:aws:proton:us-east-1:123456789012:environment-template/my-template:1.0',
+    matches: {
+      'arn:${Partition}:proton:${Region}:${Account}:environment-template/${TemplateName}:${MajorVersionId}.${MinorVersionId}': true
+    }
+  },
+  {
+    pattern: 'arn:aws:proton:us-east-1:123456789012:environment-template/my-template:1X0',
+    matches: {
+      'arn:${Partition}:proton:${Region}:${Account}:environment-template/${TemplateName}:${MajorVersionId}.${MinorVersionId}': false
+    }
+  },
+  {
+    pattern: 'arn:aws:apigateway:us-east-1::/domainnames/example.com+abc/basepathmappings/root',
+    matches: {
+      'arn:${Partition}:apigateway:${Region}::/domainnames/${DomainName}+${DomainIdentifier}/basepathmappings/${BasePath}': true
+    }
+  },
+  // Resource type variables can span resource-component separators before later static components.
+  {
+    pattern:
+      'arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/myFunction:log-stream:fh389r7cj292h',
+    matches: {
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}:log-stream:${LogStreamName}': true,
+      // This helper checks a single pattern in isolation. Choosing the most specific match
+      // from all resource type patterns belongs in callers with that broader context.
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}': true,
+      'arn:${Partition}:logs:${Region}:${Account}:destination:${DestinationName}': false
+    }
+  },
+  {
+    pattern: 'arn:aws:logs:us-east-1:123456789012:log-group:custom:group:name:log-stream:stream-id',
+    matches: {
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}:log-stream:${LogStreamName}': true,
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}': true,
+      'arn:${Partition}:logs:${Region}:${Account}:destination:${DestinationName}': false
+    }
+  },
+  {
+    pattern: 'arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/myFunction',
+    matches: {
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}': true,
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}:log-stream:${LogStreamName}': false
+    }
+  },
+  {
+    pattern: 'arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/*:log-stream:*',
+    matches: {
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}:log-stream:${LogStreamName}': true,
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}': true,
+      'arn:${Partition}:logs:${Region}:${Account}:destination:${DestinationName}': false
+    }
+  },
   // Static ARN resource-type labels can differ in case between iam-data and concrete AWS ARNs.
   {
     pattern:
@@ -151,8 +256,8 @@ const resourceStringMatchesResourcePatternTests: {
     }
   },
   // A trailing variable spans slashes, so a sub-resource ARN matches its own
-  // type AND, deliberately, its parent's. Disambiguating between the two needs
-  // the service's full type list and happens in callers that choose one type.
+  // type AND its parent's. Disambiguating between the two needs the service's
+  // full type list and belongs in callers that choose one type.
   {
     pattern:
       'arn:aws:dynamodb:us-east-1:123456789012:table/SyntheticSubscribers/stream/2024-01-01T00:00:00.000',
@@ -193,6 +298,176 @@ describe('resourceStringMatchesResourcePattern', () => {
           expect(result).toBe(expectedResult)
         })
       }
+    })
+  }
+})
+
+const mostSpecificMatchingResourceTypePatternsTests: {
+  name: string
+  resourceString: string
+  resourcePatterns: string[]
+  expected: string[]
+}[] = [
+  {
+    name: 'returns the log stream pattern instead of the parent log group pattern',
+    resourceString:
+      'arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/myFunction:log-stream:fh389r7cj292h',
+    resourcePatterns: [
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}',
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}:log-stream:${LogStreamName}',
+      'arn:${Partition}:logs:${Region}:${Account}:destination:${DestinationName}'
+    ],
+    expected: [
+      'arn:${Partition}:logs:${Region}:${Account}:log-group:${LogGroupName}:log-stream:${LogStreamName}'
+    ]
+  },
+  {
+    name: 'returns the DynamoDB stream pattern instead of the parent table pattern',
+    resourceString:
+      'arn:aws:dynamodb:us-east-1:123456789012:table/SyntheticSubscribers/stream/2024-01-01T00:00:00.000',
+    resourcePatterns: [
+      'arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}',
+      'arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}/index/${IndexName}',
+      'arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}/stream/${StreamLabel}'
+    ],
+    expected: [
+      'arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}/stream/${StreamLabel}'
+    ]
+  },
+  {
+    name: 'returns the S3 access point object pattern instead of the parent access point pattern',
+    resourceString: 'arn:aws:s3:us-east-1:123456789012:accesspoint/example-ap/object/a/b/c.txt',
+    resourcePatterns: [
+      'arn:${Partition}:s3:${Region}:${Account}:accesspoint/${AccessPointName}',
+      'arn:${Partition}:s3:${Region}:${Account}:accesspoint/${AccessPointName}/object/${ObjectName}',
+      'arn:${Partition}:s3:::${BucketName}',
+      'arn:${Partition}:s3:::${BucketName}/${ObjectName}'
+    ],
+    expected: [
+      'arn:${Partition}:s3:${Region}:${Account}:accesspoint/${AccessPointName}/object/${ObjectName}'
+    ]
+  },
+  {
+    name: 'returns the S3 object pattern instead of the bucket pattern',
+    resourceString: 'arn:aws:s3:::my-bucket/path/to/object.txt',
+    resourcePatterns: [
+      'arn:${Partition}:s3:::${BucketName}',
+      'arn:${Partition}:s3:::${BucketName}/${ObjectName}'
+    ],
+    expected: ['arn:${Partition}:s3:::${BucketName}/${ObjectName}']
+  },
+  {
+    name: 'returns the colon-delimited child pattern instead of the parent pattern',
+    resourceString: 'arn:aws:batch:us-east-1:123456789012:job-definition/synthetic-definition:3',
+    resourcePatterns: [
+      'arn:${Partition}:batch:${Region}:${Account}:job-definition/${JobDefinitionName}',
+      'arn:${Partition}:batch:${Region}:${Account}:job-definition/${JobDefinitionName}:${Revision}'
+    ],
+    expected: [
+      'arn:${Partition}:batch:${Region}:${Account}:job-definition/${JobDefinitionName}:${Revision}'
+    ]
+  },
+  {
+    name: 'returns the parent pattern for a colon-delimited parent ARN',
+    resourceString: 'arn:aws:batch:us-east-1:123456789012:job-definition/synthetic-definition',
+    resourcePatterns: [
+      'arn:${Partition}:batch:${Region}:${Account}:job-definition/${JobDefinitionName}',
+      'arn:${Partition}:batch:${Region}:${Account}:job-definition/${JobDefinitionName}:${Revision}'
+    ],
+    expected: ['arn:${Partition}:batch:${Region}:${Account}:job-definition/${JobDefinitionName}']
+  },
+  {
+    name: 'returns the child pattern when the parent pattern ends with a delimiter',
+    resourceString:
+      'arn:aws:cassandra:us-east-1:123456789012:/keyspace/synthetic-keyspace/table/synthetic-table',
+    resourcePatterns: [
+      'arn:${Partition}:cassandra:${Region}:${Account}:/keyspace/${KeyspaceName}/',
+      'arn:${Partition}:cassandra:${Region}:${Account}:/keyspace/${KeyspaceName}/table/${TableName}'
+    ],
+    expected: [
+      'arn:${Partition}:cassandra:${Region}:${Account}:/keyspace/${KeyspaceName}/table/${TableName}'
+    ]
+  },
+  {
+    name: 'returns the parent pattern for a parent ARN ending with a delimiter',
+    resourceString: 'arn:aws:cassandra:us-east-1:123456789012:/keyspace/synthetic-keyspace/',
+    resourcePatterns: [
+      'arn:${Partition}:cassandra:${Region}:${Account}:/keyspace/${KeyspaceName}/',
+      'arn:${Partition}:cassandra:${Region}:${Account}:/keyspace/${KeyspaceName}/table/${TableName}'
+    ],
+    expected: ['arn:${Partition}:cassandra:${Region}:${Account}:/keyspace/${KeyspaceName}/']
+  },
+  {
+    name: 'keeps every matching type for a wildcard resource',
+    resourceString: 'arn:aws:dynamodb:us-east-1:123456789012:table/*',
+    resourcePatterns: [
+      'arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}',
+      'arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}/stream/${StreamLabel}'
+    ],
+    expected: [
+      'arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}',
+      'arn:${Partition}:dynamodb:${Region}:${Account}:table/${TableName}/stream/${StreamLabel}'
+    ]
+  },
+  {
+    name: 'keeps multiple equally specific matching patterns',
+    resourceString: 'arn:aws:example:us-east-1:123456789012:thing/root/child/leaf',
+    resourcePatterns: [
+      'arn:${Partition}:example:${Region}:${Account}:thing/${ThingName}',
+      'arn:${Partition}:example:${Region}:${Account}:thing/${ThingName}/child/${ChildName}',
+      'arn:${Partition}:example:${Region}:${Account}:thing/${ThingName}/child/${OtherChildName}'
+    ],
+    expected: [
+      'arn:${Partition}:example:${Region}:${Account}:thing/${ThingName}/child/${ChildName}',
+      'arn:${Partition}:example:${Region}:${Account}:thing/${ThingName}/child/${OtherChildName}'
+    ]
+  },
+  {
+    name: 'preserves input order for remaining most-specific matches',
+    resourceString: 'arn:aws:example:us-east-1:123456789012:thing/root/child/leaf',
+    resourcePatterns: [
+      'arn:${Partition}:example:${Region}:${Account}:thing/${ThingName}/child/${OtherChildName}',
+      'arn:${Partition}:example:${Region}:${Account}:thing/${ThingName}',
+      'arn:${Partition}:example:${Region}:${Account}:thing/${ThingName}/child/${ChildName}'
+    ],
+    expected: [
+      'arn:${Partition}:example:${Region}:${Account}:thing/${ThingName}/child/${OtherChildName}',
+      'arn:${Partition}:example:${Region}:${Account}:thing/${ThingName}/child/${ChildName}'
+    ]
+  },
+  {
+    name: 'filters out non-matching patterns before reducing specificity',
+    resourceString: 'arn:aws:kms:us-east-1:123456789012:key/1234abcd',
+    resourcePatterns: [
+      'arn:${Partition}:kms:${Region}:${Account}:alias/${AliasName}',
+      'arn:${Partition}:kms:${Region}:${Account}:key/${KeyId}',
+      'arn:${Partition}:s3:::${BucketName}'
+    ],
+    expected: ['arn:${Partition}:kms:${Region}:${Account}:key/${KeyId}']
+  },
+  {
+    name: 'returns an empty array when no patterns match',
+    resourceString: 'arn:aws:kms:us-east-1:123456789012:key/1234abcd',
+    resourcePatterns: [
+      'arn:${Partition}:s3:::${BucketName}',
+      'arn:${Partition}:lambda:${Region}:${Account}:function:${FunctionName}'
+    ],
+    expected: []
+  }
+]
+
+describe('mostSpecificMatchingResourceTypePatterns', () => {
+  for (const testCase of mostSpecificMatchingResourceTypePatternsTests) {
+    it(testCase.name, () => {
+      // Given a resource string and candidate resource type patterns
+      const resourceString = testCase.resourceString
+      const resourcePatterns = testCase.resourcePatterns
+
+      // When the patterns are reduced to the most specific matches
+      const result = mostSpecificMatchingResourceTypePatterns(resourceString, resourcePatterns)
+
+      // Then only the most specific matching patterns are returned
+      expect(result).toEqual(testCase.expected)
     })
   }
 })

--- a/src/resourceTypes.ts
+++ b/src/resourceTypes.ts
@@ -1,11 +1,51 @@
 import { splitArnParts } from './arn.js'
-import { convertResourcePatternToRegex } from './resourcePatterns.js'
+
+/** A character matcher used by the resource pattern compatibility automaton. */
+type CharacterMatcher = 'any' | 'nonSeparator' | { char: string }
+
+/** A transition through a resource pattern compatibility automaton. */
+interface PatternTransition {
+  /** The state reached after taking the transition. */
+  nextState: number
+
+  /** The character matcher consumed by the transition, or undefined for epsilon transitions. */
+  consumes?: CharacterMatcher
+}
+
+/** A resource pattern automaton that accepts resource strings for one pattern language. */
+interface PatternAutomaton {
+  /** The accepting state for the automaton. */
+  acceptingState: number
+
+  /** Returns transitions available from the provided state. */
+  transitions(state: number): PatternTransition[]
+}
+
+/** A token in a Service Authorization Reference resource type pattern. */
+type ResourceTypeToken =
+  | {
+      /** A static literal character that must appear in the resource. */
+      type: 'literal'
+      /** The literal character to match. */
+      value: string
+    }
+  | {
+      /** A resource type variable such as `${BucketName}`. */
+      type: 'variable'
+      /** The set of characters this variable may match. */
+      characterMatcher: CharacterMatcher
+    }
 
 /**
  * Checks whether a concrete resource ARN (possibly with wildcards) matches
  * a resource-type ARN pattern from the Service Authorization Reference.
  *
  * A wildcard resource string (`"*"`) always matches.
+ *
+ * This is a compatibility check: it returns true when there is at least one
+ * concrete ARN that could satisfy both the resource string and the resource
+ * type pattern. Resource type variables may span resource-component separators
+ * such as `:` and `/`.
  *
  * @param resourceString - A concrete resource ARN or wildcard (`"*"`)
  * @param resourcePattern - An ARN pattern from iam-data (e.g. `arn:${Partition}:s3:::${BucketName}/${ObjectName}`)
@@ -42,100 +82,85 @@ export function resourceStringMatchesResourceTypePattern(
     return false
   }
 
-  const [resourceResourcePartsSegments, resourceResourceParts] = splitResourceTypeComponent(
-    resourceParts.resource
-  )
-  const [patternResourcePartsSegments, patternResourceParts] = splitResourceTypeComponent(
+  return resourceComponentMatchesResourceTypeComponent(
+    resourceParts.resource,
     patternParts.resource
   )
-
-  // If there are more segments in the resource than the pattern, it cannot match,
-  // unless the final pattern component is a variable (e.g. ${ObjectName}) which
-  // can span multiple segments (like S3 object keys with slashes).
-  if (resourceResourcePartsSegments > patternResourcePartsSegments) {
-    const lastPatternComponent = patternResourceParts.at(-1)
-    if (!isResourceTypeVariable(lastPatternComponent) || patternResourcePartsSegments === 1) {
-      return false
-    }
-  }
-
-  // If there are fewer segments with contents in the resource than the pattern, and the last segment of the resource
-  // does not end with a wildcard, it cannot match
-  if (
-    resourceResourceParts.length < patternResourceParts.length &&
-    !resourceResourceParts.at(-1)?.endsWith('*')
-  ) {
-    return false
-  }
-
-  const compareLen = Math.min(resourceResourceParts.length, patternResourceParts.length)
-  for (let i = 0; i < compareLen; i++) {
-    const resourceComponent = resourceResourceParts[i]
-    const isLastPattern = i === patternResourceParts.length - 1
-    const patternComponent = patternResourceParts[i]
-
-    if (!patternComponent) {
-      return false
-    }
-
-    if (isResourceTypeVariable(patternComponent)) {
-      if (
-        isLastPattern &&
-        resourceResourcePartsSegments > patternResourcePartsSegments &&
-        patternResourcePartsSegments > 1
-      ) {
-        // Variable at the end can absorb additional segments.
-        return true
-      }
-      if (isLastPattern && resourceComponent?.endsWith('*')) {
-        // If the resource component ends with a wildcard, it matches everything after
-        break
-      }
-
-      // These match anything, move along.
-      continue
-    }
-
-    if (!resourceComponent) {
-      return false
-    }
-
-    const resourceComponentPattern =
-      '^' + resourceComponent.replace(/\?/g, '.').replace(/\*/g, '.*?') + '$'
-    const regex = new RegExp(resourceComponentPattern, 'i')
-    const match = patternComponent.match(regex)
-    if (match) {
-      if (isLastPattern && resourceComponent.endsWith('*')) {
-        // If the resource component ends with a wildcard, it matches everything after
-        break
-      }
-      continue
-    } else {
-      return false
-    }
-  }
-
-  return true
 }
 
 /**
- * Split a resource component on colons and slashes into its segments.
+ * Reduce resource type patterns to the most specific patterns that match a resource string.
  *
- * @param component - The resource portion of an ARN
- * @returns A tuple of [total segment count, non-empty segments]
+ * This helper does not know about iam-data or service-specific resource type ordering. It uses
+ * the provided pattern set as context and removes matching parent patterns when a matching child
+ * pattern has all of the parent's literal structure plus additional literal structure. Wildcard
+ * resource strings preserve all matches because the wildcard may refer to parent and child resources.
+ *
+ * @param resourceString - A concrete resource ARN or wildcard (`"*"`)
+ * @param resourcePatterns - Candidate resource type ARN patterns
+ * @returns Matching resource type patterns with less-specific parent patterns removed, in input order
  */
-function splitResourceTypeComponent(component: string | undefined): [number, string[]] {
-  const parts = component?.split(/[:/]/) ?? []
-  return [parts.length, parts.filter((p) => p && p !== '')]
+export function mostSpecificMatchingResourceTypePatterns(
+  resourceString: string,
+  resourcePatterns: string[]
+): string[] {
+  const matchingPatterns = resourcePatterns.filter((pattern) =>
+    resourceStringMatchesResourceTypePattern(resourceString, pattern)
+  )
+
+  if (resourceString.includes('*') || resourceString.includes('?')) {
+    return matchingPatterns
+  }
+
+  return matchingPatterns.filter((candidatePattern, candidateIndex) => {
+    return !matchingPatterns.some((otherPattern, otherIndex) => {
+      return (
+        otherIndex !== candidateIndex &&
+        resourceTypePatternIsMoreSpecific(otherPattern, candidatePattern)
+      )
+    })
+  })
 }
 
 /**
- * Check whether a single ARN component from a resource string matches
- * the corresponding component from a resource-type pattern.
+ * Check whether one resource type pattern is more specific than another.
  *
- * @param resourceComponent - The component value from the concrete ARN
- * @param resourceTypeComponent - The component value from the pattern ARN
- * @returns Whether the resource component matches the pattern component
+ * @param possibleChildPattern - The pattern that may be more specific
+ * @param possibleParentPattern - The pattern that may be less specific
+ * @returns Whether the possible child has all parent literal structure plus more literal structure
+ */
+function resourceTypePatternIsMoreSpecific(
+  possibleChildPattern: string,
+  possibleParentPattern: string
+): boolean {
+  const childLiteralText = literalTextFromResourceTypePattern(possibleChildPattern)
+  const parentLiteralText = literalTextFromResourceTypePattern(possibleParentPattern)
+
+  return (
+    childLiteralText.length > parentLiteralText.length &&
+    childLiteralText.startsWith(parentLiteralText)
+  )
+}
+
+/**
+ * Extract the literal text from a resource type pattern by removing variable placeholders.
+ *
+ * @param pattern - The resource type pattern to inspect
+ * @returns Literal pattern text without `${Variable}` placeholders
+ */
+function literalTextFromResourceTypePattern(pattern: string): string {
+  return tokenizeResourceTypePattern(pattern)
+    .filter((token) => token.type === 'literal')
+    .map((token) => token.value)
+    .join('')
+}
+
+/**
+ * Check whether a resource string component is compatible with a resource type pattern component.
+ *
+ * @param resourceComponent - The component value from the concrete or wildcard ARN
+ * @param resourceTypeComponent - The component value from the resource type pattern ARN
+ * @returns Whether at least one concrete component can satisfy both component patterns
  */
 function resourceComponentMatchesResourceTypeComponent(
   resourceComponent: string | undefined,
@@ -145,39 +170,199 @@ function resourceComponentMatchesResourceTypeComponent(
     return true
   }
 
-  if (
-    resourceComponent !== undefined &&
-    resourceTypeComponent !== undefined &&
-    resourceTypeComponent.localeCompare(resourceComponent, undefined, { sensitivity: 'accent' }) ===
-      0
-  ) {
-    return true
-  }
-
-  if (!resourceComponent || !resourceTypeComponent) {
+  if (resourceComponent === undefined || resourceTypeComponent === undefined) {
     return false
   }
 
-  if (isResourceTypeVariable(resourceTypeComponent)) {
-    // If the entire component is a single variable, it matches anything
-    return true
+  if (resourceComponent === '' || resourceTypeComponent === '') {
+    return (
+      resourceComponent.localeCompare(resourceTypeComponent, undefined, {
+        sensitivity: 'accent'
+      }) === 0
+    )
   }
 
-  const pattern = convertResourcePatternToRegex(resourceTypeComponent)
-  const regex = new RegExp(pattern, 'i')
-  const match = resourceComponent.match(regex)
-  return !!match
+  return patternsHaveIntersection(
+    createResourceStringAutomaton(resourceComponent),
+    createResourceTypePatternAutomaton(resourceTypeComponent)
+  )
 }
 
 /**
- * Check whether a pattern component is a single IAM variable placeholder (e.g. `${BucketName}`).
+ * Check whether two resource pattern automata accept at least one common string.
  *
- * @param component - The component string to check
- * @returns Whether the component is a variable placeholder
+ * @param first - The first pattern automaton to compare
+ * @param second - The second pattern automaton to compare
+ * @returns Whether the pattern languages have a non-empty intersection
  */
-function isResourceTypeVariable(component: string | undefined): boolean {
-  if (!component) {
-    return false
+function patternsHaveIntersection(first: PatternAutomaton, second: PatternAutomaton): boolean {
+  const visited = new Set<string>()
+  const queue: [number, number][] = [[0, 0]]
+
+  while (queue.length > 0) {
+    const [firstState, secondState] = queue.shift()!
+    const key = `${firstState}:${secondState}`
+    if (visited.has(key)) {
+      continue
+    }
+    visited.add(key)
+
+    if (firstState === first.acceptingState && secondState === second.acceptingState) {
+      return true
+    }
+
+    const firstTransitions = first.transitions(firstState)
+    const secondTransitions = second.transitions(secondState)
+
+    for (const transition of firstTransitions) {
+      if (!transition.consumes) {
+        queue.push([transition.nextState, secondState])
+      }
+    }
+
+    for (const transition of secondTransitions) {
+      if (!transition.consumes) {
+        queue.push([firstState, transition.nextState])
+      }
+    }
+
+    for (const firstTransition of firstTransitions) {
+      if (!firstTransition.consumes) {
+        continue
+      }
+
+      for (const secondTransition of secondTransitions) {
+        if (!secondTransition.consumes) {
+          continue
+        }
+
+        if (characterMatchersIntersect(firstTransition.consumes, secondTransition.consumes)) {
+          queue.push([firstTransition.nextState, secondTransition.nextState])
+        }
+      }
+    }
   }
-  return component.match(/^\$\{[0-9a-zA-Z]+\}$/) !== null
+
+  return false
+}
+
+/**
+ * Create an automaton for a resource string that may contain IAM wildcards.
+ *
+ * @param resourceString - The resource string component to convert
+ * @returns An automaton accepting concrete strings matched by the resource string
+ */
+function createResourceStringAutomaton(resourceString: string): PatternAutomaton {
+  const chars = [...resourceString]
+  return {
+    acceptingState: chars.length,
+    transitions(state: number): PatternTransition[] {
+      if (state >= chars.length) {
+        return []
+      }
+
+      const char = chars[state]
+      if (char === '*') {
+        return [{ nextState: state + 1 }, { nextState: state, consumes: 'any' }]
+      }
+      if (char === '?') {
+        return [{ nextState: state + 1, consumes: 'any' }]
+      }
+      return [{ nextState: state + 1, consumes: { char } }]
+    }
+  }
+}
+
+/**
+ * Create an automaton for a Service Authorization Reference resource type component.
+ *
+ * @param resourceTypePattern - The resource type component to convert
+ * @returns An automaton accepting concrete strings matched by the resource type component
+ */
+function createResourceTypePatternAutomaton(resourceTypePattern: string): PatternAutomaton {
+  const tokens = tokenizeResourceTypePattern(resourceTypePattern)
+  return {
+    acceptingState: tokens.length,
+    transitions(state: number): PatternTransition[] {
+      if (state >= tokens.length) {
+        return []
+      }
+
+      const token = tokens[state]
+      if (token.type === 'variable') {
+        return [
+          { nextState: state, consumes: token.characterMatcher },
+          { nextState: state + 1, consumes: token.characterMatcher }
+        ]
+      }
+      return [{ nextState: state + 1, consumes: { char: token.value } }]
+    }
+  }
+}
+
+/**
+ * Tokenize a Service Authorization Reference resource type pattern.
+ *
+ * @param pattern - The resource type pattern component to tokenize
+ * @returns Tokens representing literals and `${Variable}` placeholders
+ */
+function tokenizeResourceTypePattern(pattern: string): ResourceTypeToken[] {
+  const tokens: ResourceTypeToken[] = []
+  const variableMatches = [...pattern.matchAll(/\$\{[0-9a-zA-Z]+\}/g)]
+  const patternIsSingleVariable = variableMatches.length === 1 && variableMatches[0]![0] === pattern
+
+  for (let i = 0; i < pattern.length;) {
+    if (pattern[i] === '$' && pattern[i + 1] === '{') {
+      const endIndex = pattern.indexOf('}', i + 2)
+      if (endIndex !== -1) {
+        tokens.push({
+          type: 'variable',
+          characterMatcher: patternIsSingleVariable ? 'nonSeparator' : 'any'
+        })
+        i = endIndex + 1
+        continue
+      }
+    }
+
+    tokens.push({ type: 'literal', value: pattern[i] })
+    i++
+  }
+  return tokens
+}
+
+/**
+ * Check whether two character matchers can consume the same character.
+ *
+ * @param first - The first character matcher
+ * @param second - The second character matcher
+ * @returns Whether the matchers have a non-empty intersection
+ */
+function characterMatchersIntersect(first: CharacterMatcher, second: CharacterMatcher): boolean {
+  if (first === 'any' || second === 'any') {
+    return true
+  }
+
+  if (first === 'nonSeparator' && second === 'nonSeparator') {
+    return true
+  }
+
+  if (first === 'nonSeparator') {
+    return typeof second === 'object' && !isResourceComponentSeparator(second.char)
+  }
+
+  if (second === 'nonSeparator') {
+    return typeof first === 'object' && !isResourceComponentSeparator(first.char)
+  }
+
+  return first.char.localeCompare(second.char, undefined, { sensitivity: 'accent' }) === 0
+}
+
+/**
+ * Check whether a character is a resource component separator.
+ *
+ * @param char - The character to check
+ * @returns Whether the character separates resource component segments
+ */
+function isResourceComponentSeparator(char: string): boolean {
+  return char === ':' || char === '/'
 }


### PR DESCRIPTION
## Summary
- replace resource-type matching with an automaton-based compatibility matcher that supports separator-spanning variables, IAM wildcards, and case-insensitive static text
- add `mostSpecificMatchingResourceTypePatterns` to reduce matching candidate patterns to the most-specific concrete-resource matches while preserving wildcard ambiguity
- export the new helper and add array-driven tests for S3, CloudWatch Logs, DynamoDB, Batch, Cassandra, wildcard, and literal metacharacter cases

## Tests
- `npm test`
- `npm run format-check`
- `npm run build`
